### PR TITLE
Instruct to explicitly call make clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 mkdir CODK && cd $_
 git clone https://github.com/01org/CODK-A.git
 cd CODK-A
+make clone
 sudo make install-dep
 make setup
 ```


### PR DESCRIPTION
`install-dep` needs the repos to exist
`setup` needs `install-dep`

Therefore, we need to `clone` before `install-dep`
