### PR TITLE
Correct default project description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ export CODK_DIR=$(pwd)
 - ARC: `make upload-arc-jtag`
 - Both: `make upload-jtag`
 
-Default app blinks the pin-13 LED on Arduino 101 board
+Default app prints the ASCII table over the serial port.
+To see the output, connect at 9600 bps to the CDC ACM virtual serial port
+the Arduino 101 shows up under, e.g. `/dev/ttyACM0`.
 
 #### BLE Firmware
 Curie ODK requires an updated BLE firmware. If you're on a factory version, please update.    


### PR DESCRIPTION
While README says Blink is the default ARC project, ASCIITable is actually set as such and this PR fixes that.

This IMHO makes more sense that correcting docs, because Blink works better as a very basic example, not requiring any user activity to work properly.

ASCIITable has a problem in that it uses `Serial` for output and that is not easily accessible when one works directly with Arduino 101 using Serial-to-USB converter. ~At least I haven't been able to see any output by connecting to `/dev/ttyACM0` and only changing that to `Serial1` and connecting to Arduino pins 0 and 1 through the Serial-to-USB converter allowed me to make sure the default project and CODK-A actually work ok for me.~ EDIT: okay, that was probably my serial client, with `screen` I can see the output by simply connecting to /dev/ttyACM0, but I still believe Blink makes more sense as the need to connect to ttyACM0 is not documented anywhere and may not be intuitive for new users.